### PR TITLE
Rearranged the positions of the Buy and Sell buttons for the Bull and Bear Pool, and implemented the Explore page.

### DIFF
--- a/src/app/usePool/[id]/page.tsx
+++ b/src/app/usePool/[id]/page.tsx
@@ -72,7 +72,6 @@ const UseFatePools = () => {
           id: objectID,
           options: { showContent: true },
         });
-        console.log("getobject response", response)
         if (!response.data?.content) {
           throw new Error("No content found in response");
         }
@@ -90,8 +89,6 @@ const UseFatePools = () => {
             options: { showContent: true },
           }),
         ]);
-        console.log("bull response", bullResponse);
-        console.log("bear response", bearResponse);
         if (!bullResponse.data?.content || !bearResponse.data?.content) {
           throw new Error("Failed to fetch token details");
         }
@@ -139,7 +136,6 @@ const UseFatePools = () => {
         };
 
         setPool(newPool);
-        console.log("Pool data:", newPool);
 
       } catch (err) {
         console.error("Error fetching prediction pool:", err);

--- a/src/components/Forms/CreateFatePool.tsx
+++ b/src/components/Forms/CreateFatePool.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
 import {
   Card,
   CardContent,
@@ -26,6 +27,7 @@ import { useWallet } from "@suiet/wallet-kit";
 
 export default function CreateFatePoolForm() {
   const { account, signAndExecuteTransaction } = useWallet();
+  const router = useRouter();
   // Separate state variables for each field
   const [poolName, setPoolName] = useState("");
   const [bullCoinName, setBullCoinName] = useState("");
@@ -93,9 +95,10 @@ export default function CreateFatePoolForm() {
       const result = await signAndExecuteTransaction({
         transaction: tx,
       });
-
+      router.push("/explorePools")
       console.log("Transaction result:", result);
       alert("Prediction Pool created successfully!");
+
 
     } catch (err: any) {
       console.error("Transaction error:", err);

--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -2,8 +2,10 @@
 import React, { useState, useEffect } from 'react';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 const Hero = () => {
+  const router = useRouter();
   const { resolvedTheme } = useTheme();
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   const [lightOn, setLightOn] = useState(false);
@@ -13,7 +15,7 @@ const Hero = () => {
 
   const handleSubmit = () => {
     if (vaultAddress) {
-      window.location.href = `/usePool/${vaultAddress}`;
+      router.push(`/usePool/${vaultAddress}`);
     }
   };
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -138,7 +138,7 @@ const Navbar = () => {
                 ? "bg-white text-black hover:bg-gray-200"
                 : "bg-black text-white hover:bg-gray-200"
                 }`}
-            />
+            >Connect Wallet</ConnectButton>
           </div>
           <ModeToggle />
         </div>


### PR DESCRIPTION
- Implemented logic to fetch all pools created under the specified PACKAGE_ID
- Reorganized the UI by moving the Buy and Sell buttons under their respective Bull and Bear token sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Explore Pools page now displays dynamically fetched on-chain pool and token data, including detailed token information and live percentages.
  - Pool cards support navigation to detailed usage pages.
  - Vault Actions section in pool details now features separate cards for Bear and Bull Pools with distinct buy/sell inputs and actions.
  - Added a "Distribute Rewards" button in the pool interaction view.

- **Improvements**
  - Navigation across the app now uses seamless client-side routing for a smoother user experience.
  - "Connect Wallet" button in the Navbar now clearly displays its label.
  - UI enhancements for pool creation, pool cards, and input fields for improved clarity and usability.

- **Bug Fixes**
  - Removed unnecessary console log statements for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->